### PR TITLE
Add MCP server for license name lookup

### DIFF
--- a/ldbcollector.cabal
+++ b/ldbcollector.cabal
@@ -32,6 +32,7 @@ library
       Ldbcollector.Model.LicenseName
       Ldbcollector.Model.LicenseStatement
       Ldbcollector.Model.OutputLicense
+      Ldbcollector.MCPServer
       Ldbcollector.Server
       Ldbcollector.Sink.GraphViz
       Ldbcollector.Sink.JSON
@@ -94,6 +95,7 @@ library
     , http-conduit
     , hslogger
     , libyaml
+    , mcp-server
     , mtl
     , network-uri
     , opensource

--- a/src/Ldbcollector/MCPServer.hs
+++ b/src/Ldbcollector/MCPServer.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ldbcollector.MCPServer
+  ( serveMCPHttp,
+  )
+where
+
+import Control.Exception (SomeException, catch)
+import Data.ByteString.Lazy qualified as BL
+import Data.Vector qualified as V
+import Ldbcollector.Model
+import MCP.Server qualified as MCP
+import MCP.Server.Types qualified as MCP
+import System.Environment qualified as Env
+
+-- | Run the MCP server over HTTP (Streamable HTTP transport).
+-- Takes a fully-loaded LicenseGraph and serves it on the configured port.
+serveMCPHttp :: LicenseGraph -> IO ()
+serveMCPHttp licenseGraph = do
+  mcpPort <- maybe 3001 read <$> Env.lookupEnv "MCP_PORT"
+  putStrLn $ "MCP_PORT=" ++ show mcpPort
+  let config =
+        MCP.HttpConfig
+          { MCP.httpPort = mcpPort,
+            MCP.httpHost = "localhost",
+            MCP.httpEndpoint = "/mcp",
+            MCP.httpVerbose = False
+          }
+  MCP.runMcpServerHttpWithConfig config mcpServerInfo (mcpHandlers licenseGraph)
+
+mcpServerInfo :: MCP.McpServerInfo
+mcpServerInfo =
+  MCP.McpServerInfo
+    { MCP.serverName = "ldbcollector",
+      MCP.serverVersion = "0.1.0.0",
+      MCP.serverInstructions =
+        "License database collector MCP server. "
+          <> "Use the lookup_license_names tool to find alternative names for a license."
+    }
+
+mcpHandlers :: LicenseGraph -> MCP.McpServerHandlers IO
+mcpHandlers licenseGraph =
+  MCP.McpServerHandlers
+    { MCP.prompts = Nothing,
+      MCP.resources = Nothing,
+      MCP.tools = Just (toolListHandler, toolCallHandler licenseGraph)
+    }
+
+-- | List all available tools.
+toolListHandler :: MCP.ToolListHandler IO
+toolListHandler =
+  pure
+    [ MCP.ToolDefinition
+        { MCP.toolDefinitionName = "lookup_license_names",
+          MCP.toolDefinitionDescription =
+            "Given a license name, returns all known alternative names "
+              <> "(same licenses) and related names (hints/imprecise matches) "
+              <> "from the license database.",
+          MCP.toolDefinitionInputSchema =
+            MCP.InputSchemaDefinitionObject
+              { MCP.properties =
+                  [ ( "licenseName",
+                      MCP.InputSchemaDefinitionProperty
+                        { MCP.propertyType = "string",
+                          MCP.propertyDescription =
+                            "The license name to look up, e.g. 'MIT', 'Apache-2.0', 'spdx:GPL-3.0-only'"
+                        }
+                    )
+                  ],
+                MCP.required = ["licenseName"]
+              },
+          MCP.toolDefinitionTitle = Just "Lookup License Names"
+        }
+    ]
+
+-- | Handle tool calls by dispatching on tool name.
+toolCallHandler :: LicenseGraph -> MCP.ToolCallHandler IO
+toolCallHandler licenseGraph toolName args =
+  case toolName of
+    "lookup_license_names" -> lookupLicenseNames licenseGraph args
+    _ -> pure $ Left $ MCP.UnknownTool toolName
+
+-- | Look up alternative names for a license.
+lookupLicenseNames :: LicenseGraph -> [(MCP.ArgumentName, MCP.ArgumentValue)] -> IO (Either MCP.Error MCP.Content)
+lookupLicenseNames licenseGraph args =
+  case lookup "licenseName" args of
+    Nothing -> pure $ Left $ MCP.MissingRequiredParams "licenseName"
+    Just licenseNameText -> do
+      let ln = fromText licenseNameText
+          needle = LGName ln
+      result <- lookupCluster licenseGraph needle
+      case result of
+        Nothing ->
+          pure . Right . MCP.ContentText $
+            "No license found for: " <> licenseNameText
+        Just cluster ->
+          let jsonText = (bsToText . BL.toStrict . encodePretty) cluster
+           in pure . Right . MCP.ContentText $ jsonText
+
+-- | Run the graph focus algorithm to compute the LicenseNameCluster
+-- for a given license graph node.
+lookupCluster :: LicenseGraph -> LicenseGraphNode -> IO (Maybe LicenseNameCluster)
+lookupCluster licenseGraph needle =
+  ( do
+      (result, _) <-
+        runLicenseGraphM' licenseGraph $
+          focus mempty (V.singleton needle) $
+            \(needleNames, sameNames, otherNames, _statements) ->
+              getLicenseNameClusterM (needleNames, sameNames, otherNames)
+      pure (Just result)
+  )
+    `catch` (\(_ :: SomeException) -> pure Nothing)

--- a/src/Ldbcollector/Server.hs
+++ b/src/Ldbcollector/Server.hs
@@ -9,6 +9,7 @@ module Ldbcollector.Server
   )
 where
 
+import Control.Concurrent (forkIO)
 import Control.Monad.State qualified as MTL
 import Data.ByteString qualified
 import Data.ByteString.Lazy qualified as BL
@@ -23,6 +24,7 @@ import Data.Map qualified as Map
 import Data.Text.Lazy qualified as T
 import Data.Text.Lazy.IO qualified as I
 import Data.Vector qualified as V
+import Ldbcollector.MCPServer (serveMCPHttp)
 import Ldbcollector.Model
 import Ldbcollector.Sink.GraphViz
 import Network.Wai.Handler.Warp qualified as Warp
@@ -358,6 +360,9 @@ serve = do
   clusters <- getClusters
 
   lift $ do
+    -- Start MCP server in a background thread
+    _ <- forkIO $ serveMCPHttp licenseGraph
+
     cache <- C.newCache Nothing
     let init params = do
           paramMap <- evaluateParams params


### PR DESCRIPTION
Introduce an HTTP Streamable MCP server (mcp-server library) that runs alongside the Scotty web UI via forkIO. Exposes a lookup_license_names tool that returns alternative/related names for a given license.